### PR TITLE
Now setting title attribute on iframe element for PDF.js

### DIFF
--- a/PdfEmbedPlugin.php
+++ b/PdfEmbedPlugin.php
@@ -92,6 +92,7 @@ class PdfEmbedPlugin extends Omeka_Plugin_AbstractPlugin
             . '?file=' . rawurlencode($file->getWebPath('original'))
             . $hash;
         $attrs['style'] = "width: 100%; height: {$height}px";
+        $attrs['title'] = $file->original_filename;
         $attrString = tag_attributes($attrs);
 
         return "<iframe {$attrString}></iframe>";


### PR DESCRIPTION
Hi all, 

Just a small change for accessibility. The WCAG 2.0 guideline suggests that the title element should be set on iframe elements. So, here I'm just setting it to the original file name of the item being viewed.

For more information see: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#ensure-compat-rsv
and specifically: http://www.w3.org/TR/WCAG20-TECHS/H64.html

-Adam
